### PR TITLE
Add Provider to LeafMarkdown

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,13 +35,23 @@ Add LeafMarkdown as a dependency in your `Package.swift` file:
     ]
 ```
 
+### Add the Provider
+
+You can add a provider to you `Droplet`, which will do all of the setup for you and register your tag. Just add it as so:
+
+```swift
+let drop = Droplet()
+try drop.addProvider(LeafMarkdownProvider.self)
+```
+
+
 ### Register with Leaf
 
-During your setup (for example, in `main.swift`), register your tag as so:
+Alternatively, you can also directly add the Tag onto your `LeafRenderer` if desired. During your setup (for example, in `main.swift`), register your tag as so:
 
 ```swift
 if let leaf = drop.view as? LeafRenderer {
-    leaf.stem.register(Markdown())
+    leaf.stem.register(LeafMardownTag())
 }
 ```
 

--- a/Sources/LeafMarkdown/LeafMarkdownProvider.swift
+++ b/Sources/LeafMarkdown/LeafMarkdownProvider.swift
@@ -1,0 +1,21 @@
+import Vapor
+
+public struct LeafMarkdownProvider: Provider {
+    
+    public var provided: Providable = Providable()
+    
+    public func boot(_ drop: Droplet) {
+        guard let renderer = drop.view as? LeafRenderer else {
+            print("LeafMarkdown only supports Leaf as a renderer")
+            return
+        }
+        
+        renderer.stem.register(LeafMarkdownTag())
+    }
+    
+    public init(config: Config) throws {}
+    public init() {}
+    
+    public func afterInit(_: Vapor.Droplet) {}
+    public func beforeRun(_: Vapor.Droplet) {}
+}

--- a/Sources/LeafMarkdown/LeafMarkdownTag.swift
+++ b/Sources/LeafMarkdown/LeafMarkdownTag.swift
@@ -1,7 +1,7 @@
 import Leaf
 import SwiftMarkdown
 
-public final class Markdown: BasicTag {
+public final class LeafMarkdownTag: BasicTag {
     
     public enum Error: Swift.Error {
         case expectedVariable(Argument?)
@@ -10,7 +10,7 @@ public final class Markdown: BasicTag {
     
     public init() { }
      
-    public let name = "markdown"
+    public let name = "LeafMarkdown"
     
     public func run(arguments: [Argument]) throws -> Node? {
         guard let markdownArgument = arguments.first else {

--- a/Tests/LeafMarkdownTests/LeafTests.swift
+++ b/Tests/LeafMarkdownTests/LeafTests.swift
@@ -10,7 +10,7 @@ class LeafTests: XCTestCase {
     ]
     
     func testRunTag() {
-        let tag = Markdown()
+        let tag = LeafMarkdownTag()
         let inputMarkdown = "# This is a test\n\nWe have some text in a tag"
         let expectedHtml = "<h1>This is a test</h1>\n<p>We have some text in a tag</p>\n"
         

--- a/Tests/LeafMarkdownTests/ProviderTests.swift
+++ b/Tests/LeafMarkdownTests/ProviderTests.swift
@@ -1,0 +1,41 @@
+import XCTest
+import Vapor
+
+@testable import LeafMarkdown
+
+class ProviderTests: XCTestCase {
+    static var allTests = [
+        ("testProviderCreation", testProviderAddsTagToLeaf),
+        ("testProviderGracefullyHandlesNonLeafRenderer", testProviderGracefullyHandlesNonLeafRenderer)
+    ]
+    
+    func testProviderAddsTagToLeaf() {
+        let drop = Droplet()
+        let leafProvider = LeafMarkdownProvider()
+        leafProvider.boot(drop)
+        
+        guard let leaf = drop.view as? LeafRenderer else {
+            XCTFail()
+            return
+        }
+        
+        XCTAssertNotNil(leaf.stem.tags[LeafMarkdownTag().name])
+    }
+    
+    func testProviderGracefullyHandlesNonLeafRenderer() {
+        let drop = Droplet()
+        let stubbedRenderer = StubbedRenderer(viewsDir: "")
+        drop.view = stubbedRenderer
+        let leafProvider = LeafMarkdownProvider()
+        leafProvider.boot(drop)
+        XCTAssert(true, "We should reach this point")
+    }
+}
+
+struct StubbedRenderer: ViewRenderer {
+    init(viewsDir: String) {}
+    
+    func make(_ path: String, _ context: Node) throws -> View {
+        return try View(bytes: "Stubbed renderer".bytes)
+    }
+}

--- a/Tests/LinuxMain.swift
+++ b/Tests/LinuxMain.swift
@@ -3,5 +3,6 @@ import XCTest
 @testable import LeafMarkdownTests
 
 XCTMain([
-    testCase(LeafTests.allTests)
+    testCase(LeafTests.allTests),
+    testCase(ProviderTests.allTests)
 ])


### PR DESCRIPTION
This PR renames the LeafMarkdownTag class for clarity and adds a provider for easy adding to `Droplet`s. 