### PR TITLE
Add GFM

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -5,6 +5,6 @@ let package = Package(
     dependencies: [
     	.Package(url: "https://github.com/vapor/vapor.git", Version(2,0,0, prereleaseIdentifiers: ["beta"])),
         .Package(url: "https://github.com/vapor/leaf-provider.git", Version(1,0,0, prereleaseIdentifiers: ["beta"])),
-    	.Package(url: "https://github.com/brokenhandsio/SwiftMarkdown.git", majorVersion: 0, minor: 1)
+    	.Package(url: "https://github.com/brokenhandsio/SwiftMarkdown.git", majorVersion: 0, minor: 2)
     ]
 )


### PR DESCRIPTION
This pulls in the latest release of SwiftMarkdown which uses a fork of Github's cmark fork so it will support Github Flavoured Markdown!